### PR TITLE
Add a name field to Location

### DIFF
--- a/src/main/java/uk/ac/sanger/storelight/model/Location.java
+++ b/src/main/java/uk/ac/sanger/storelight/model/Location.java
@@ -14,13 +14,14 @@ import static uk.ac.sanger.storelight.utils.BasicUtils.repr;
  */
 @Entity
 public class Location {
-    public static final int MAX_DESCRIPTION = 256;
+    public static final int MAX_DESCRIPTION = 256, MAX_NAME = 64;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
     private String barcode;
+    private String name;
     private String description;
     @ManyToOne(fetch = FetchType.LAZY)
     private Location parent;
@@ -39,16 +40,17 @@ public class Location {
     private List<Item> stored;
 
     public Location() {
-        this(null, null, null, null, null, null, null);
+        this(null, null, null, null, null, null, null, null);
     }
 
     public Location(Integer id, String barcode) {
-        this(id, barcode, null, null, null, null, null);
+        this(id, barcode, null, null, null, null, null, null);
     }
 
-    public Location(Integer id, String barcode, String description, Location parent, Address address, Size size, GridDirection direction) {
+    public Location(Integer id, String barcode, String name, String description, Location parent, Address address, Size size, GridDirection direction) {
         this.id = id;
         this.barcode = barcode;
+        this.name = name;
         this.description = description;
         this.parent = parent;
         this.address = address;
@@ -72,6 +74,14 @@ public class Location {
 
     public void setBarcode(String barcode) {
         this.barcode = barcode;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public String getDescription() {
@@ -137,6 +147,7 @@ public class Location {
         Location that = (Location) o;
         return (Objects.equals(this.id, that.id)
                 && Objects.equals(this.barcode, that.barcode)
+                && Objects.equals(this.name, that.name)
                 && Objects.equals(this.description, that.description)
                 && Objects.equals(this.address, that.address)
                 && Objects.equals(this.size, that.size)
@@ -153,6 +164,7 @@ public class Location {
         return MoreObjects.toStringHelper(this)
                 .add("id", id)
                 .add("barcode", repr(barcode))
+                .add("name", repr(name))
                 .add("description", repr(description))
                 .add("address", address)
                 .add("size", size)

--- a/src/main/java/uk/ac/sanger/storelight/requests/LocationInput.java
+++ b/src/main/java/uk/ac/sanger/storelight/requests/LocationInput.java
@@ -12,6 +12,7 @@ import static uk.ac.sanger.storelight.utils.BasicUtils.repr;
  * @author dr6
  */
 public class LocationInput {
+    private String name;
     private String description;
     private Integer parentId;
     private Address address;
@@ -20,12 +21,22 @@ public class LocationInput {
 
     public LocationInput() {}
 
-    public LocationInput(String description, Integer parentId, Address address, Size size, GridDirection direction) {
+    public LocationInput(String name, String description, Integer parentId, Address address, Size size, GridDirection direction) {
+        this.name = name;
         this.description = description;
         this.parentId = parentId;
         this.address = address;
         this.size = size;
         this.direction = direction;
+    }
+
+    /** A name of this location (does not have to be unique). */
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**
@@ -95,6 +106,7 @@ public class LocationInput {
         if (o == null || getClass() != o.getClass()) return false;
         LocationInput that = (LocationInput) o;
         return (Objects.equals(this.description, that.description)
+                && Objects.equals(this.name, that.name)
                 && Objects.equals(this.parentId, that.parentId)
                 && Objects.equals(this.address, that.address)
                 && Objects.equals(this.size, that.size)
@@ -103,12 +115,13 @@ public class LocationInput {
 
     @Override
     public int hashCode() {
-        return Objects.hash(description, parentId, address, size);
+        return Objects.hash(name, description, parentId, address, size);
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
+                .add("name", repr(name))
                 .add("description", repr(description))
                 .add("parentId", parentId)
                 .add("address", address)

--- a/src/main/java/uk/ac/sanger/storelight/service/LocationService.java
+++ b/src/main/java/uk/ac/sanger/storelight/service/LocationService.java
@@ -62,8 +62,17 @@ public class LocationService {
                 throw new IllegalArgumentException("Location description is too long (max length: "+Location.MAX_DESCRIPTION+").");
             }
         }
+        String name = lin.getName();
+        if (name!=null) {
+            name = name.trim();
+            if (name.isEmpty()) {
+                name = null;
+            } else if (name.length() > Location.MAX_NAME) {
+                throw new IllegalArgumentException("Location name is too long (max length: "+Location.MAX_NAME+").");
+            }
+        }
         String barcode = db.getBarcodeSeedRepo().createStoreBarcode();
-        Location loc = new Location(null, barcode, desc, parent, address, lin.getSize(), lin.getDirection());
+        Location loc = new Location(null, barcode, name, desc, parent, address, lin.getSize(), lin.getDirection());
         Location savedLoc = db.getLocationRepo().save(loc);
         log.info("New location created {} by {}.", savedLoc, context);
         return savedLoc;
@@ -97,6 +106,20 @@ public class LocationService {
                     if (!Objects.equals(location.getDescription(), desc)) {
                         changed = true;
                         location.setDescription(desc);
+                    }
+                    break;
+                }
+                case "name": {
+                    String name = (String) entry.getValue();
+                    if (name != null) {
+                        name = name.trim();
+                        if (name.isEmpty()) {
+                            name = null;
+                        }
+                    }
+                    if (!Objects.equals(location.getName(), name)) {
+                        changed = true;
+                        location.setName(name);
                     }
                     break;
                 }
@@ -188,6 +211,21 @@ public class LocationService {
                     int len = ((String) value).trim().length();
                     if (len > Location.MAX_DESCRIPTION) {
                         problems.add(String.format("Description too long (%s). Max length is %s.", len, Location.MAX_DESCRIPTION));
+                    }
+                    break;
+                }
+
+                case "name": {
+                    if (value==null) {
+                        break;
+                    }
+                    if (!(value instanceof String)) {
+                        problems.add(fieldTypeError("name", "a string", value));
+                        break;
+                    }
+                    int len = ((String) value).trim().length();
+                    if (len > Location.MAX_NAME) {
+                        problems.add(String.format("Name too long (%s). Max length is %s.", len, Location.MAX_NAME));
                     }
                     break;
                 }

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -59,6 +59,8 @@ type Location {
     id: Int!,
     """The barcode of the location."""
     barcode: String!,
+    """A name for the location (non-unique)."""
+    name: String,
     """The description of the location, if it has one."""
     description: String, # a location may have a description
     """The location that this location is inside, if any."""
@@ -88,6 +90,8 @@ input StoreInput {
 
 """A specification of a location."""
 input LocationInput {
+    """A name (if any) for the location (non-unique)."""
+    name: String,
     """The description (if any) that the location should have."""
     description: String,
     """The id of the location that the location should be inside (if any)."""

--- a/src/test/java/uk/ac/sanger/storelight/IntegrationTests.java
+++ b/src/test/java/uk/ac/sanger/storelight/IntegrationTests.java
@@ -43,6 +43,7 @@ public class IntegrationTests {
             Object response = tester.post(query);
             Object locData = chainGet(response, "data", "location");
             assertEquals(chainGet(locData, "barcode"), freezerLi.getBarcode());
+            assertEquals(chainGet(locData, "name"), "Freezer Alpha");
             assertEquals(chainGet(locData, "id"), freezerId);
             assertEquals(chainGet(locData, "description"), "A freezer.");
             assertNull(chainGet(locData, "size"));
@@ -90,6 +91,7 @@ public class IntegrationTests {
         response = tester.post(editMutation);
         Map<String,?> info = chainGet(response, "data", "editLocation");
         assertEquals(id, info.get("id"));
+        assertEquals("New name", info.get("name"));
         assertEquals("I like describing things.", info.get("description"));
         assertEquals(Map.of("numRows", 10, "numColumns", 11), info.get("size"));
         assertEquals("F12", info.get("address").toString());

--- a/src/test/java/uk/ac/sanger/storelight/repo/TestLocationRepo.java
+++ b/src/test/java/uk/ac/sanger/storelight/repo/TestLocationRepo.java
@@ -25,7 +25,7 @@ public class TestLocationRepo {
     @Test
     @Transactional
     public void testSaveLocation() {
-        Location parent = new Location(null, "STO-001F", "parent desc", null, null, null, null);
+        Location parent = new Location(null, "STO-001F", "parent", "parent desc", null, null, null, null);
         parent = locationRepo.save(parent);
         checkLocation(parent, null, "STO-001F", "parent desc", null, null, null, null);
         assertThat(parent.getChildren()).isEmpty();
@@ -34,7 +34,7 @@ public class TestLocationRepo {
         parent = locationRepo.getById(parentId);
         checkLocation(parent, parentId, "STO-001F", "parent desc", null, null, null, null);
 
-        Location loc1 = new Location(null, "STO-002E", "loc1 desc", parent,
+        Location loc1 = new Location(null, "STO-002E", "loc1", "loc1 desc", parent,
                 new Address(2,3), new Size(4,5), GridDirection.RightDown);
         loc1 = locationRepo.save(loc1);
         checkLocation(loc1, null, "STO-002E", "loc1 desc", parentId, new Address(2,3),

--- a/src/test/java/uk/ac/sanger/storelight/service/TestLocationCache.java
+++ b/src/test/java/uk/ac/sanger/storelight/service/TestLocationCache.java
@@ -31,7 +31,7 @@ public class TestLocationCache {
     void setup() {
         mockLocationRepo = mock(LocationRepo.class);
         locations = IntStream.range(1, 6)
-                .mapToObj(id -> new Location(id, "STO-"+id, null, null, null, null, null))
+                .mapToObj(id -> new Location(id, "STO-"+id))
                 .collect(toList());
         when(mockLocationRepo.findAllById(any())).thenAnswer(invocation -> {
             Set<Integer> ids = invocation.getArgument(0);

--- a/src/test/java/uk/ac/sanger/storelight/service/TestLocationService.java
+++ b/src/test/java/uk/ac/sanger/storelight/service/TestLocationService.java
@@ -69,50 +69,54 @@ public class TestLocationService {
     }
 
     static Stream<Arguments> createLocationArguments() {
-        Location par1 = new Location(1, "STO-1", null, null, null, null, null);
-        Location par2 = new Location(2, "STO-2", null, null, null, new Size(2, 2), null);
+        Location par1 = new Location(1, "STO-1");
+        Location par2 = new Location(2, "STO-2", null, null, null, null, new Size(2, 2), null);
         Address A1 = new Address(1, 1);
         Address A2 = new Address(1, 2);
         Address A3 = new Address(1, 3);
-        Location loc3 = new Location(3, "STO-3", null, par1, A2, null, null);
+        Location loc3 = new Location(3, "STO-3", null, null, par1, A2, null, null);
         par1.getChildren().add(loc3);
         String longDescription = IntStream.range(0, Location.MAX_DESCRIPTION/2).mapToObj(String::valueOf).collect(Collectors.joining());
 
         return Arrays.stream(new Object[][]{
                 {
-                        new Location(null, NEWBC, null, null, null, null, null),
-                        new LocationInput(null, null, null, null, null)
+                        new Location(null, NEWBC, null, null, null, null, null, null),
+                        new LocationInput(null, null, null, null, null, null)
                 },
                 {
-                        new Location(null, NEWBC, null, null, null, null, null),
-                        new LocationInput("    ", null, null, null, null)
+                        new Location(null, NEWBC, null, null, null, null, null, null),
+                        new LocationInput("   ", "    ", null, null, null, null)
                 },
                 {
-                        new Location(null, NEWBC, "Bananas", par1, A1, new Size(3, 4), null),
-                        new LocationInput("Bananas ", par1.getId(), A1, new Size(3, 4), null),
+                        new Location(null, NEWBC, "Alpha", "Bananas", par1, A1, new Size(3, 4), null),
+                        new LocationInput("Alpha  ", "Bananas ", par1.getId(), A1, new Size(3, 4), null),
                         par1
                 },
                 {
                         EntityNotFoundException.class,
-                        new LocationInput(null, 404, null, null, null),
+                        new LocationInput(null, null, 404, null, null, null),
                 },
                 {
                         "A location with no parent cannot have an address.",
-                        new LocationInput(null, null, A1, null, null)
+                        new LocationInput(null, null, null, A1, null, null)
                 },
                 {
                         "The address A3 is outside the listed size (numRows=2, numColumns=2) for the parent.",
-                        new LocationInput(null, par2.getId(), A3, null, null),
+                        new LocationInput(null, null, par2.getId(), A3, null, null),
                         par2
                 },
                 {
                         "There is already a location at address A2 in the parent.",
-                        new LocationInput(null, par1.getId(), A2, null, null),
+                        new LocationInput(null, null, par1.getId(), A2, null, null),
                         par1
                 },
                 {
                         "Location description is too long (max length: "+Location.MAX_DESCRIPTION+").",
-                        new LocationInput(longDescription, null, null, null, null)
+                        new LocationInput(null, longDescription, null, null, null, null)
+                },
+                {
+                        "Location name is too long (max length: "+Location.MAX_NAME+").",
+                        new LocationInput(longDescription, null, null, null, null, null)
                 },
         }).map(arr -> (arr.length==2 ? Arguments.of(arr[0], arr[1], null) : Arguments.of(arr)));
     }
@@ -177,14 +181,15 @@ public class TestLocationService {
                 Arguments.of(new Location(3, "STO-3"), noChange, null, null),
                 Arguments.of(new Location(3, "STO-3"), blankAll, null, null),
                 Arguments.of(new Location(3, "STO-3"), Map.of("description", "    "), null, null),
-                Arguments.of(new Location(3, "STO-3"), changeAll, newParent, new Location(3, "STO-3", "New description.", newParent, B3, size45, null)),
+                Arguments.of(new Location(3, "STO-3"), Map.of("name", "    "), null, null),
+                Arguments.of(new Location(3, "STO-3"), changeAll, newParent, new Location(3, "STO-3", null, "New description.", newParent, B3, size45, null)),
 
-                Arguments.of(new Location(3, "STO-3", "Complex location.", parent, A2, size34, null), noChange, null, null),
-                Arguments.of(new Location(3, "STO-3", "Complex location.", parent, A2, size34, null), Map.of("description", "   "),
-                        parent, new Location(3, "STO-3", null, parent, A2, size34, null)),
-                Arguments.of(new Location(3, "STO-3", "Complex location.", parent, A2, size34, null), changeAll, newParent,
-                        new Location(3, "STO-3", "New description.", newParent, B3, size45, null)),
-                Arguments.of(new Location(3, "STO-3", "Complex location.", parent, A2, size34, null), blankAll, null,
+                Arguments.of(new Location(3, "STO-3", null, "Complex location.", parent, A2, size34, null), noChange, null, null),
+                Arguments.of(new Location(3, "STO-3", null, "Complex location.", parent, A2, size34, null), Map.of("description", "   "),
+                        parent, new Location(3, "STO-3", null, null, parent, A2, size34, null)),
+                Arguments.of(new Location(3, "STO-3", null, "Complex location.", parent, A2, size34, null), changeAll, newParent,
+                        new Location(3, "STO-3", null, "New description.", newParent, B3, size45, null)),
+                Arguments.of(new Location(3, "STO-3", null, "Complex location.", parent, A2, size34, null), blankAll, null,
                         new Location(3, "STO-3"))
         );
     }
@@ -228,7 +233,7 @@ public class TestLocationService {
         a.getChildren().add(c);
         final Address A1 = new Address(1,1);
         final Map<String, Integer> sizeMap = Map.of("numRows", 2, "numColumns", 3);
-        final Map<String, Object> fullFields = Map.of("address", A1, "description", "Ilikepie", "parentId", b.getId(), "size", sizeMap);
+        final Map<String, Object> fullFields = Map.of("address", A1, "name", "newname", "description", "Ilikepie", "parentId", b.getId(), "size", sizeMap);
         final Map<String, Object> nullFields = new HashMap<>(fullFields.size());
         for (String key : fullFields.keySet()) {
             nullFields.put(key, null);
@@ -246,6 +251,8 @@ public class TestLocationService {
                 new ValidateChangesData(c).changes(fullFields).parent(b).newAddress(A1).parentError("Problem with parent and address.").expectedError("Problem with parent and address."),
                 new ValidateChangesData(c).change("description", longDesc).expectedError(longDescError),
                 new ValidateChangesData(c).change("description", 17).expectedError("Require description to be a string, but received java.lang.Integer."),
+                new ValidateChangesData(c).change("name", 20).expectedError("Require name to be a string, but received java.lang.Integer."),
+                new ValidateChangesData(c).change("name", longDesc).expectedError("Name too long ("+longDesc.length()+"). Max length is "+Location.MAX_NAME+"."),
                 new ValidateChangesData(c).change("parentId", c.getId()).expectedError("A location cannot be its own parent."),
                 new ValidateChangesData(c).change("parentId", "Bananas").expectedError("Require parentId to be an integer, but received java.lang.String."),
                 new ValidateChangesData(c).change("parentId", 404).expectedError("Invalid parent id: 404."),
@@ -268,11 +275,11 @@ public class TestLocationService {
     }
 
     static Stream<Arguments> checkParentWithAddressArguments() {
-        Location loc1 = new Location(1, "STO-1", null, null, null, null, null);
-        Location loc2 = new Location(2, "STO-2", null, null, null, new Size(2,2), null);
-        Location loc3 = new Location(3, "STO-3", null, loc1, new Address(3,4), null, null);
+        Location loc1 = new Location(1, "STO-1", null, null, null, null, null, null);
+        Location loc2 = new Location(2, "STO-2", null, null, null, null, new Size(2,2), null);
+        Location loc3 = new Location(3, "STO-3", null, null, loc1, new Address(3,4), null, null);
         loc1.getChildren().add(loc3);
-        Location loc4 = new Location(4, "STO-4", null, null, null, null, null);
+        Location loc4 = new Location(4, "STO-4", null, null, null, null, null, null);
         return Stream.of(
                 Arguments.of(loc4, loc1, new Address(1,2), null),
                 Arguments.of(loc4, loc1, null, null, null),
@@ -292,11 +299,11 @@ public class TestLocationService {
     }
 
     static Stream<Arguments> checkCycleArguments() {
-        Location a = new Location(1, "STO-1", null, null, null, null, null);
-        Location a1 = new Location(2, "STO-2", null, a, null, null, null);
-        Location a2 = new Location(3, "STO-3", null, a, null, null, null);
-        Location b = new Location(4, "STO-4", null, null, null, null, null);
-        Location a11 = new Location(5, "STO-5", null, a1, null, null, null);
+        Location a = new Location(1, "STO-1", null, null, null, null, null, null);
+        Location a1 = new Location(2, "STO-2", null, null, a, null, null, null);
+        Location a2 = new Location(3, "STO-3", null, null, a, null, null, null);
+        Location b = new Location(4, "STO-4", null, null, null, null, null, null);
+        Location a11 = new Location(5, "STO-5", null, null, a1, null, null, null);
 
         a.getChildren().add(a1);
         a.getChildren().add(a2);

--- a/src/test/java/uk/ac/sanger/storelight/service/TestStoreAddressChecker.java
+++ b/src/test/java/uk/ac/sanger/storelight/service/TestStoreAddressChecker.java
@@ -33,8 +33,8 @@ public class TestStoreAddressChecker {
     }
 
     static Stream<Arguments> checkItemsArguments() {
-        final Location loc1 = new Location(1, "STO-1", null, null, null, null, null);
-        final Location loc2 = new Location(2, "STO-2", null, null, null, new Size(2,2), null);
+        final Location loc1 = new Location(1, "STO-1", null, null, null, null, null, null);
+        final Location loc2 = new Location(2, "STO-2", null, null, null, null, new Size(2,2), null);
         final String loc1desc = "location (id=1, barcode=\"STO-1\")";
         final String loc2desc = "location (id=2, barcode=\"STO-2\")";
         final String loc2descSize = loc2desc + " (numRows=2, numColumns=2)";

--- a/src/test/java/uk/ac/sanger/storelight/service/TestStoreService.java
+++ b/src/test/java/uk/ac/sanger/storelight/service/TestStoreService.java
@@ -100,7 +100,7 @@ public class TestStoreService {
         Location loc1 = new Location(1, "STO-1");
         Item occupant = new Item(100, "ITEM-100", loc1, A2);
         loc1.getStored().add(occupant);
-        Location loc2 = new Location(2, "STO-2", null, null, null, new Size(2, 2), null);
+        Location loc2 = new Location(2, "STO-2", null, null, null, null, new Size(2, 2), null);
         return Stream.of(
                 StoreBarcodeTestData.make()
                         .location(loc1)

--- a/src/test/java/uk/ac/sanger/storelight/service/TestUnstoreService.java
+++ b/src/test/java/uk/ac/sanger/storelight/service/TestUnstoreService.java
@@ -10,7 +10,6 @@ import uk.ac.sanger.storelight.requests.LocationIdentifier;
 import javax.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/resources/graphql/addfreezer.graphql
+++ b/src/test/resources/graphql/addfreezer.graphql
@@ -1,6 +1,7 @@
 mutation {
     addLocation(location:{
         description: "A freezer."
+        name: "Freezer Alpha"
     }) {
         barcode
         id

--- a/src/test/resources/graphql/editlocation.graphql
+++ b/src/test/resources/graphql/editlocation.graphql
@@ -1,12 +1,14 @@
 mutation {
     editLocation(location: {id:1}, change: {
         address: "F12"
+        name: "New name"
         description: " I like describing things. "
         size: {numRows: 10, numColumns: 11}
         direction: DownRight
     }) {
         id
         barcode
+        name
         description
         size {numRows, numColumns}
         address

--- a/src/test/resources/graphql/getlocation.graphql
+++ b/src/test/resources/graphql/getlocation.graphql
@@ -2,6 +2,7 @@
     location(location: {id:1}) {
         barcode
         id
+        name
         description
         address
         size { numRows, numColumns}


### PR DESCRIPTION
Against the likelihood that at some point we need to get a qualified name from locations
(e.g. Freezer Alpha/Drawer 1/Box 3 etc.), I've added a non-unique name field to location.

Requires recreating the db from updated sql in the storelight sql repo.