### PR TITLE
x1078 support "addressIndex" field for stored items

### DIFF
--- a/src/main/java/uk/ac/sanger/storelight/model/Item.java
+++ b/src/main/java/uk/ac/sanger/storelight/model/Item.java
@@ -1,5 +1,6 @@
 package uk.ac.sanger.storelight.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.MoreObjects;
 
 import javax.persistence.*;
@@ -72,6 +73,14 @@ public class Item {
 
     public void setAddress(Address address) {
         this.address = address;
+    }
+
+    @JsonIgnore
+    public Integer getAddressIndex() {
+        if (this.address==null || this.location==null) {
+            return null;
+        }
+        return this.location.addressIndex(this.address);
     }
 
     private boolean sameLocationAs(Item that) {

--- a/src/main/java/uk/ac/sanger/storelight/model/Location.java
+++ b/src/main/java/uk/ac/sanger/storelight/model/Location.java
@@ -6,7 +6,8 @@ import com.google.common.base.MoreObjects;
 import javax.persistence.*;
 import java.util.*;
 
-import static uk.ac.sanger.storelight.utils.BasicUtils.*;
+import static uk.ac.sanger.storelight.utils.BasicUtils.newArrayList;
+import static uk.ac.sanger.storelight.utils.BasicUtils.repr;
 
 /**
  * A location that might contain stored items or other locations
@@ -216,5 +217,22 @@ public class Location {
                 .add("direction", direction)
                 .omitNullValues()
                 .toString();
+    }
+
+    /**
+     * The index of the given address in this location, if such a thing can be deduced.
+     * @param address the address inside this location
+     * @return the index of the given address, starting from 1; or null
+     */
+    public Integer addressIndex(Address address) {
+        if (address!=null && size!=null && direction!=null && size.contains(address)) {
+            switch (direction) {
+                case RightDown: return (address.getRow()-1) * size.getNumColumns() + address.getColumn();
+                case DownRight: return (address.getColumn()-1) * size.getNumRows() + address.getRow();
+                case RightUp: return (size.getNumRows()-address.getRow()) * size.getNumColumns() + address.getColumn();
+                case UpRight: return (address.getColumn()-1) * size.getNumRows() + size.getNumRows() - address.getRow() + 1;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -34,11 +34,13 @@ input LocationIdentifier {
 """An item stored in the system."""
 type Item {
     """The unique barcode of the stored item."""
-    barcode: String!, # a stored item must have a barcode
+    barcode: String! # a stored item must have a barcode
     """The location where the item is stored."""
-    location: Location!, # a stored item must have a location
+    location: Location! # a stored item must have a location
     """The address (if applicable) inside the location where the thing is stored."""
-    address: Address, # a stored item may have an address inside its location
+    address: Address # a stored item may have an address inside its location
+    """The index of this address inside its location, if such a thing makes sense."""
+    addressIndex: Int
 }
 
 """A type containing a list of items that are stored."""

--- a/src/test/java/uk/ac/sanger/storelight/model/TestItem.java
+++ b/src/test/java/uk/ac/sanger/storelight/model/TestItem.java
@@ -1,0 +1,25 @@
+package uk.ac.sanger.storelight.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests {@link Item}
+ * @author dr6
+ */
+public class TestItem {
+    @Test
+    public void testGetAddressIndex() {
+        Location loc = new Location(1, "STO-1");
+        loc.setDirection(GridDirection.RightDown);
+        loc.setSize(new Size(2, 3));
+        Item item = new Item(1, "ITEM-1", loc, new Address(2,3));
+        assertEquals(6, item.getAddressIndex());
+        item.setAddress(new Address(1,2));
+        assertEquals(2, item.getAddressIndex());
+        item.setAddress(null);
+        assertNull(item.getAddressIndex());
+    }
+}

--- a/src/test/java/uk/ac/sanger/storelight/model/TestLocation.java
+++ b/src/test/java/uk/ac/sanger/storelight/model/TestLocation.java
@@ -1,15 +1,15 @@
 package uk.ac.sanger.storelight.model;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.*;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiPredicate;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@link Location}
@@ -44,6 +44,49 @@ public class TestLocation {
     @MethodSource("getHierarchyArgs")
     public void testGetHierarchy(List<Location> expected) {
         assertThat(expected.get(expected.size()-1).getHierarchy()).containsExactlyElementsOf(expected);
+    }
+
+    @ParameterizedTest
+    @EnumSource(GridDirection.class)
+    public void testAddressIndex(GridDirection direction) {
+        int rows = 2, cols = 3;
+        Size size = new Size(rows, cols);
+        Location loc = new Location();
+        loc.setSize(size);
+        loc.setDirection(direction);
+        Address[] addresses = new Address[rows*cols];
+        for (int row = 1; row <= rows; ++row) {
+            for (int col = 1; col <= cols; ++col) {
+                final Address address = new Address(row, col);
+                int i = loc.addressIndex(address);
+                assertThat(i).isBetween(1, addresses.length);
+                addresses[i-1] = address;
+            }
+        }
+        assertNull(loc.addressIndex(new Address(1, cols+1)));
+        assertNull(loc.addressIndex(new Address(rows+1, 1)));
+        BiPredicate<Address, Address> predicate = addressOrderPredicate(direction);
+        Address prev = null;
+        for (Address address : addresses) {
+            if (prev!=null) {
+                assertTrue(predicate.test(prev, address));
+            }
+            prev = address;
+        }
+    }
+
+    private static BiPredicate<Address, Address> addressOrderPredicate(GridDirection direction) {
+        switch (direction) {
+            case RightDown:
+                return (a,b) -> b.getRow() > a.getRow() || b.getRow()==a.getRow() && b.getColumn() > a.getColumn();
+            case DownRight:
+                return (a,b) -> b.getColumn() > a.getColumn() || a.getColumn()==b.getColumn() && b.getRow() > a.getRow();
+            case RightUp:
+                return (a,b) -> b.getRow() < a.getRow() || b.getRow()==a.getRow() && b.getColumn() > a.getColumn();
+            case UpRight:
+                return (a,b) -> b.getColumn() > a.getColumn() || b.getColumn()==b.getColumn() && b.getRow() < a.getRow();
+        }
+        throw new IllegalArgumentException("Unknown direction "+direction);
     }
 
     static Stream<Arguments> getHierarchyArgs() {

--- a/src/test/resources/graphql/addsizedfreezer.graphql
+++ b/src/test/resources/graphql/addsizedfreezer.graphql
@@ -1,0 +1,11 @@
+mutation {
+    addLocation(location:{
+        description: "A freezer."
+        name: "Freezer Alpha"
+        size: {numColumns: 3, numRows: 2}
+        direction: RightDown
+    }) {
+        barcode
+        id
+    }
+}

--- a/src/test/resources/graphql/getstored.graphql
+++ b/src/test/resources/graphql/getstored.graphql
@@ -2,6 +2,7 @@
     stored(barcodes:[]) {
         barcode
         address
+        addressIndex
         location { id }
     }
 }


### PR DESCRIPTION
The addressIndex field is calculated according
to the listed size and direction of the location,
so client applications don't have to load those fields and figure it out themselves.
